### PR TITLE
image list maximum gets 25, modify api gets all images

### DIFF
--- a/client/applications/dashboard/modules/image/cache.js
+++ b/client/applications/dashboard/modules/image/cache.js
@@ -3,10 +3,10 @@ const fetch = require('client/applications/dashboard/cores/fetch');
 module.exports = {
   getImageList: function() {
     return fetch.get({
-      //url: '/api/v1/images'
-      url: '/proxy-search/glance/v2/images'
+      url: '/api/v1/images'
+      //url: '/proxy-search/glance/v2/images'
     }).then(function(data) {
-      return data.list;
+      return data.images;
     });
   }
 };


### PR DESCRIPTION
现在API获取的image list最多只有25个，当镜像数量大于25时不能获取全部的镜像，故修改api使得可以获取全部镜像