### PR TITLE
fix module config init bug

### DIFF
--- a/client/applications/dashboard/config.json.sample
+++ b/client/applications/dashboard/config.json.sample
@@ -98,7 +98,6 @@
   "default_hide_modules": [
     "ike-policy",
     "ipsec-policy",
-    "instance-public",
     "volume-public"
   ]
 }


### PR DESCRIPTION
dashboard's default_hide_modules has a key which doesn't exist

Type: BF